### PR TITLE
Use opam lockfiles

### DIFF
--- a/.github/workflows/build-eio.yml
+++ b/.github/workflows/build-eio.yml
@@ -15,25 +15,24 @@ jobs:
             os:
                - ubuntu-latest
             ocaml-compiler:
-               - "5.1"
+               - "5.4"
 
       runs-on: ${{ matrix.os }}
       steps:
-         - uses: actions/checkout@main
+         - uses: actions/checkout@v6
          - name: Use OCaml ${{ matrix.ocaml-compiler }}
-           uses: ocaml/setup-ocaml@v2
+           uses: ocaml/setup-ocaml@v3
            with:
               ocaml-compiler: ${{ matrix.ocaml-compiler }}
               dune-cache: true
               opam-pin: false
-              opam-depext: false
          - run: opam pin . -y -n
-         - run: opam install -t ambient-context-eio
+         - run: opam install ambient-context-eio --locked --deps-only --with-doc --with-test --with-dev-setup
          - run: opam exec -- dune build @install --only-packages=ambient-context,ambient-context-eio
-         - run: opam exec -- dune runtest --only-packages=ambient-context,ambient-context-eio
+         - run: opam exec -- dune runtest -f --only-packages=ambient-context,ambient-context-eio
 
          # now redo it with hmap installed
          - run: opam install hmap
 
          - run: opam exec -- dune build @install --only-packages=ambient-context,ambient-context-eio
-         - run: opam exec -- dune runtest --only-packages=ambient-context,ambient-context-eio
+         - run: opam exec -- dune runtest -f --only-packages=ambient-context,ambient-context-eio

--- a/.github/workflows/build-eio.yml
+++ b/.github/workflows/build-eio.yml
@@ -17,7 +17,7 @@ jobs:
             os:
                - ubuntu-latest
             ocaml-compiler:
-               - "5.4"
+               - "5.3"
 
       runs-on: ${{ matrix.os }}
       steps:
@@ -52,7 +52,7 @@ jobs:
             os:
                - ubuntu-latest
             ocaml-compiler:
-               - "5.4"
+               - "5.3"
 
       runs-on: ${{ matrix.os }}
       steps:

--- a/.github/workflows/build-eio.yml
+++ b/.github/workflows/build-eio.yml
@@ -37,12 +37,6 @@ jobs:
          - run: opam exec -- dune build @install --only-packages=ambient-context,ambient-context-eio
          - run: opam exec -- dune runtest -f --only-packages=ambient-context,ambient-context-eio
 
-         # now redo it with hmap installed
-         - run: opam install hmap
-
-         - run: opam exec -- dune build @install --only-packages=ambient-context,ambient-context-eio
-         - run: opam exec -- dune runtest -f --only-packages=ambient-context,ambient-context-eio
-
    test-latest:
       name: build w/ Eio (latest deps)
       # Only run on schedule
@@ -71,11 +65,5 @@ jobs:
 
          - run: opam pin . -y -n
          - run: opam install ambient-context-eio --deps-only --with-doc --with-test --with-dev-setup
-         - run: opam exec -- dune build @install --only-packages=ambient-context,ambient-context-eio
-         - run: opam exec -- dune runtest -f --only-packages=ambient-context,ambient-context-eio
-
-         # now redo it with hmap installed
-         - run: opam install hmap
-
          - run: opam exec -- dune build @install --only-packages=ambient-context,ambient-context-eio
          - run: opam exec -- dune runtest -f --only-packages=ambient-context,ambient-context-eio

--- a/.github/workflows/build-eio.yml
+++ b/.github/workflows/build-eio.yml
@@ -17,7 +17,8 @@ jobs:
          matrix:
             os:
                - ubuntu-latest
-               - macos-latest
+               - macos-latest # arm64
+               - macos-15-intel
                - windows-latest
             ocaml-compiler:
                - "5.3"
@@ -48,7 +49,8 @@ jobs:
          matrix:
             os:
                - ubuntu-latest
-               - macos-latest
+               - macos-latest # arm64
+               - macos-15-intel
                - windows-latest
             ocaml-compiler:
                - "5.3"

--- a/.github/workflows/build-eio.yml
+++ b/.github/workflows/build-eio.yml
@@ -11,11 +11,14 @@ on:
 jobs:
    test-locked:
       name: build w/ Eio (locked deps)
+      continue-on-error: ${{ matrix.os != 'ubuntu-latest' }}
       strategy:
          fail-fast: false
          matrix:
             os:
                - ubuntu-latest
+               - macos-latest
+               - windows-latest
             ocaml-compiler:
                - "5.3"
 
@@ -51,6 +54,8 @@ jobs:
          matrix:
             os:
                - ubuntu-latest
+               - macos-latest
+               - windows-latest
             ocaml-compiler:
                - "5.3"
 

--- a/.github/workflows/build-eio.yml
+++ b/.github/workflows/build-eio.yml
@@ -5,12 +5,14 @@ on:
       branches:
          - main
    pull_request:
+   schedule:
+      - cron: "0 0 1,15 * *" # Biweekly on 1st and 15th
 
 jobs:
-   run:
-      name: build w/ Eio
+   test-locked:
+      name: build w/ Eio (locked deps)
       strategy:
-         fail-fast: true
+         fail-fast: false
          matrix:
             os:
                - ubuntu-latest
@@ -26,8 +28,44 @@ jobs:
               ocaml-compiler: ${{ matrix.ocaml-compiler }}
               dune-cache: true
               opam-pin: false
+
          - run: opam pin . -y -n
          - run: opam install ambient-context-eio --locked --deps-only --with-doc --with-test --with-dev-setup
+         - run: opam exec -- dune build @install --only-packages=ambient-context,ambient-context-eio
+         - run: opam exec -- dune runtest -f --only-packages=ambient-context,ambient-context-eio
+
+         # now redo it with hmap installed
+         - run: opam install hmap
+
+         - run: opam exec -- dune build @install --only-packages=ambient-context,ambient-context-eio
+         - run: opam exec -- dune runtest -f --only-packages=ambient-context,ambient-context-eio
+
+   test-latest:
+      name: build w/ Eio (latest deps)
+      # Only run on schedule
+      if: github.event_name == 'schedule'
+      continue-on-error: true
+
+      strategy:
+         fail-fast: false
+         matrix:
+            os:
+               - ubuntu-latest
+            ocaml-compiler:
+               - "5.4"
+
+      runs-on: ${{ matrix.os }}
+      steps:
+         - uses: actions/checkout@v6
+         - name: Use OCaml ${{ matrix.ocaml-compiler }}
+           uses: ocaml/setup-ocaml@v3
+           with:
+              ocaml-compiler: ${{ matrix.ocaml-compiler }}
+              dune-cache: true
+              opam-pin: false
+
+         - run: opam pin . -y -n
+         - run: opam install ambient-context-eio --deps-only --with-doc --with-test --with-dev-setup
          - run: opam exec -- dune build @install --only-packages=ambient-context,ambient-context-eio
          - run: opam exec -- dune runtest -f --only-packages=ambient-context,ambient-context-eio
 

--- a/.github/workflows/build-lwt.yml
+++ b/.github/workflows/build-lwt.yml
@@ -17,7 +17,8 @@ jobs:
          matrix:
             os:
                - ubuntu-latest
-               - macos-latest
+               - macos-latest # arm64
+               - macos-15-intel
                - windows-latest
             ocaml-compiler:
                - "4.08"
@@ -25,6 +26,8 @@ jobs:
                - "5.3"
             exclude:
                - os: windows-latest
+                 ocaml-compiler: "4.08"
+               - os: macos-latest
                  ocaml-compiler: "4.08"
 
       runs-on: ${{ matrix.os }}
@@ -59,7 +62,8 @@ jobs:
          matrix:
             os:
                - ubuntu-latest
-               - macos-latest
+               - macos-latest # arm64
+               - macos-15-intel
                - windows-latest
             ocaml-compiler:
                - "4.08"
@@ -67,6 +71,8 @@ jobs:
                - "5.3"
             exclude:
                - os: windows-latest
+                 ocaml-compiler: "4.08"
+               - os: macos-latest
                  ocaml-compiler: "4.08"
 
       runs-on: ${{ matrix.os }}

--- a/.github/workflows/build-lwt.yml
+++ b/.github/workflows/build-lwt.yml
@@ -19,7 +19,7 @@ jobs:
             ocaml-compiler:
                - "4.08"
                - "4.14"
-               - "5.4"
+               - "5.3"
 
       runs-on: ${{ matrix.os }}
       steps:
@@ -56,7 +56,7 @@ jobs:
             ocaml-compiler:
                - "4.08"
                - "4.14"
-               - "5.4"
+               - "5.3"
 
       runs-on: ${{ matrix.os }}
       steps:

--- a/.github/workflows/build-lwt.yml
+++ b/.github/workflows/build-lwt.yml
@@ -17,25 +17,24 @@ jobs:
             ocaml-compiler:
                - "4.08"
                - "4.14"
-               - "5.1"
+               - "5.4"
 
       runs-on: ${{ matrix.os }}
       steps:
-         - uses: actions/checkout@main
+         - uses: actions/checkout@v6
          - name: Use OCaml ${{ matrix.ocaml-compiler }}
-           uses: ocaml/setup-ocaml@v2
+           uses: ocaml/setup-ocaml@v3
            with:
               ocaml-compiler: ${{ matrix.ocaml-compiler }}
               dune-cache: true
               opam-pin: false
-              opam-depext: false
          - run: opam pin . -y -n
-         - run: opam install -t ambient-context-lwt
+         - run: opam install ambient-context-lwt --locked --deps-only --with-doc --with-test --with-dev-setup
          - run: opam exec -- dune build @install --only-packages=ambient-context,ambient-context-lwt
-         - run: opam exec -- dune runtest --only-packages=ambient-context,ambient-context-lwt
+         - run: opam exec -- dune runtest -f --only-packages=ambient-context,ambient-context-lwt
 
          # now redo it with hmap installed
          - run: opam install hmap
 
          - run: opam exec -- dune build @install --only-packages=ambient-context,ambient-context-lwt
-         - run: opam exec -- dune runtest --only-packages=ambient-context,ambient-context-lwt
+         - run: opam exec -- dune runtest -f --only-packages=ambient-context,ambient-context-lwt

--- a/.github/workflows/build-lwt.yml
+++ b/.github/workflows/build-lwt.yml
@@ -11,15 +11,21 @@ on:
 jobs:
    test-locked:
       name: build w/ Lwt (locked deps)
+      continue-on-error: ${{ matrix.os != 'ubuntu-latest' }}
       strategy:
          fail-fast: false
          matrix:
             os:
                - ubuntu-latest
+               - macos-latest
+               - windows-latest
             ocaml-compiler:
                - "4.08"
                - "4.14"
                - "5.3"
+            exclude:
+               - os: windows-latest
+                 ocaml-compiler: "4.08"
 
       runs-on: ${{ matrix.os }}
       steps:
@@ -53,10 +59,15 @@ jobs:
          matrix:
             os:
                - ubuntu-latest
+               - macos-latest
+               - windows-latest
             ocaml-compiler:
                - "4.08"
                - "4.14"
                - "5.3"
+            exclude:
+               - os: windows-latest
+                 ocaml-compiler: "4.08"
 
       runs-on: ${{ matrix.os }}
       steps:

--- a/.github/workflows/build-lwt.yml
+++ b/.github/workflows/build-lwt.yml
@@ -5,12 +5,14 @@ on:
       branches:
          - main
    pull_request:
+   schedule:
+      - cron: "0 0 1,15 * *" # Biweekly on 1st and 15th
 
 jobs:
-   run:
-      name: build w/ Lwt
+   test-locked:
+      name: build w/ Lwt (locked deps)
       strategy:
-         fail-fast: true
+         fail-fast: false
          matrix:
             os:
                - ubuntu-latest
@@ -28,8 +30,46 @@ jobs:
               ocaml-compiler: ${{ matrix.ocaml-compiler }}
               dune-cache: true
               opam-pin: false
+
          - run: opam pin . -y -n
          - run: opam install ambient-context-lwt --locked --deps-only --with-doc --with-test --with-dev-setup
+         - run: opam exec -- dune build @install --only-packages=ambient-context,ambient-context-lwt
+         - run: opam exec -- dune runtest -f --only-packages=ambient-context,ambient-context-lwt
+
+         # now redo it with hmap installed
+         - run: opam install hmap
+
+         - run: opam exec -- dune build @install --only-packages=ambient-context,ambient-context-lwt
+         - run: opam exec -- dune runtest -f --only-packages=ambient-context,ambient-context-lwt
+
+   test-latest:
+      name: build w/ Lwt (latest deps)
+      # Only run on schedule
+      if: github.event_name == 'schedule'
+      continue-on-error: true
+
+      strategy:
+         fail-fast: false
+         matrix:
+            os:
+               - ubuntu-latest
+            ocaml-compiler:
+               - "4.08"
+               - "4.14"
+               - "5.4"
+
+      runs-on: ${{ matrix.os }}
+      steps:
+         - uses: actions/checkout@v6
+         - name: Use OCaml ${{ matrix.ocaml-compiler }}
+           uses: ocaml/setup-ocaml@v3
+           with:
+              ocaml-compiler: ${{ matrix.ocaml-compiler }}
+              dune-cache: true
+              opam-pin: false
+
+         - run: opam pin . -y -n
+         - run: opam install ambient-context-lwt --deps-only --with-doc --with-test --with-dev-setup
          - run: opam exec -- dune build @install --only-packages=ambient-context,ambient-context-lwt
          - run: opam exec -- dune runtest -f --only-packages=ambient-context,ambient-context-lwt
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,26 +19,25 @@ jobs:
             ocaml-compiler:
                - "4.08"
                - "4.14"
-               - "5.1"
+               - "5.4"
 
       runs-on: ${{ matrix.os }}
       steps:
-         - uses: actions/checkout@main
+         - uses: actions/checkout@v6
          - name: Use OCaml ${{ matrix.ocaml-compiler }}
-           uses: ocaml/setup-ocaml@v2
+           uses: ocaml/setup-ocaml@v3
            with:
               ocaml-compiler: ${{ matrix.ocaml-compiler }}
               dune-cache: true
               opam-pin: false
-              opam-depext: false
 
          - run: opam pin . -y -n
-         - run: opam install -t ambient-context --deps-only
+         - run: opam install ambient-context --locked --deps-only --with-doc --with-test --with-dev-setup
          - run: opam exec -- dune build @install --only-packages=ambient-context
-         - run: opam exec -- dune runtest --only-packages=ambient-context
+         - run: opam exec -- dune runtest -f --only-packages=ambient-context
 
          # now redo it with hmap installed
          - run: opam install hmap
 
          - run: opam exec -- dune build @install --only-packages=ambient-context
-         - run: opam exec -- dune runtest --only-packages=ambient-context
+         - run: opam exec -- dune runtest -f --only-packages=ambient-context

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,12 +5,14 @@ on:
       branches:
          - main
    pull_request:
+   schedule:
+      - cron: "0 0 1,15 * *" # Biweekly on 1st and 15th
 
 jobs:
-   run:
-      name: build w/ only TLS
+   test-locked:
+      name: build w/ only TLS (locked deps)
       strategy:
-         fail-fast: true
+         fail-fast: false
          matrix:
             os:
                - ubuntu-latest
@@ -33,6 +35,45 @@ jobs:
 
          - run: opam pin . -y -n
          - run: opam install ambient-context --locked --deps-only --with-doc --with-test --with-dev-setup
+         - run: opam exec -- dune build @install --only-packages=ambient-context
+         - run: opam exec -- dune runtest -f --only-packages=ambient-context
+
+         # now redo it with hmap installed
+         - run: opam install hmap
+
+         - run: opam exec -- dune build @install --only-packages=ambient-context
+         - run: opam exec -- dune runtest -f --only-packages=ambient-context
+
+   test-latest:
+      name: build w/ only TLS (latest deps)
+      # Only run on schedule
+      if: github.event_name == 'schedule'
+      continue-on-error: true
+
+      strategy:
+         fail-fast: false
+         matrix:
+            os:
+               - ubuntu-latest
+                 #- macos-latest
+                 #- windows-latest
+            ocaml-compiler:
+               - "4.08"
+               - "4.14"
+               - "5.4"
+
+      runs-on: ${{ matrix.os }}
+      steps:
+         - uses: actions/checkout@v6
+         - name: Use OCaml ${{ matrix.ocaml-compiler }}
+           uses: ocaml/setup-ocaml@v3
+           with:
+              ocaml-compiler: ${{ matrix.ocaml-compiler }}
+              dune-cache: true
+              opam-pin: false
+
+         - run: opam pin . -y -n
+         - run: opam install ambient-context --deps-only --with-doc --with-test --with-dev-setup
          - run: opam exec -- dune build @install --only-packages=ambient-context
          - run: opam exec -- dune runtest -f --only-packages=ambient-context
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,8 @@ jobs:
          matrix:
             os:
                - ubuntu-latest
-               - macos-latest
+               - macos-latest # arm64
+               - macos-15-intel
                - windows-latest
             ocaml-compiler:
                - "4.08"
@@ -25,6 +26,8 @@ jobs:
                - "5.3"
             exclude:
                - os: windows-latest
+                 ocaml-compiler: "4.08"
+               - os: macos-latest
                  ocaml-compiler: "4.08"
 
       runs-on: ${{ matrix.os }}
@@ -59,7 +62,8 @@ jobs:
          matrix:
             os:
                - ubuntu-latest
-               - macos-latest
+               - macos-latest # arm64
+               - macos-15-intel
                - windows-latest
             ocaml-compiler:
                - "4.08"
@@ -67,6 +71,8 @@ jobs:
                - "5.3"
             exclude:
                - os: windows-latest
+                 ocaml-compiler: "4.08"
+               - os: macos-latest
                  ocaml-compiler: "4.08"
 
       runs-on: ${{ matrix.os }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
             ocaml-compiler:
                - "4.08"
                - "4.14"
-               - "5.4"
+               - "5.3"
 
       runs-on: ${{ matrix.os }}
       steps:
@@ -60,7 +60,7 @@ jobs:
             ocaml-compiler:
                - "4.08"
                - "4.14"
-               - "5.4"
+               - "5.3"
 
       runs-on: ${{ matrix.os }}
       steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,17 +11,21 @@ on:
 jobs:
    test-locked:
       name: build w/ only TLS (locked deps)
+      continue-on-error: ${{ matrix.os != 'ubuntu-latest' }}
       strategy:
          fail-fast: false
          matrix:
             os:
                - ubuntu-latest
-                 #- macos-latest
-                 #- windows-latest
+               - macos-latest
+               - windows-latest
             ocaml-compiler:
                - "4.08"
                - "4.14"
                - "5.3"
+            exclude:
+               - os: windows-latest
+                 ocaml-compiler: "4.08"
 
       runs-on: ${{ matrix.os }}
       steps:
@@ -55,12 +59,15 @@ jobs:
          matrix:
             os:
                - ubuntu-latest
-                 #- macos-latest
-                 #- windows-latest
+               - macos-latest
+               - windows-latest
             ocaml-compiler:
                - "4.08"
                - "4.14"
                - "5.3"
+            exclude:
+               - os: windows-latest
+                 ocaml-compiler: "4.08"
 
       runs-on: ${{ matrix.os }}
       steps:

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -10,10 +10,10 @@ jobs:
       name: Deploy doc
       runs-on: ubuntu-latest
       steps:
-         - uses: actions/checkout@main
+         - uses: actions/checkout@v6
 
          - name: Use OCaml
-           uses: ocaml/setup-ocaml@v2
+           uses: ocaml/setup-ocaml@v3
            with:
               ocaml-compiler: "5.1"
               dune-cache: true

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -15,7 +15,7 @@ jobs:
          - name: Use OCaml
            uses: ocaml/setup-ocaml@v3
            with:
-              ocaml-compiler: "5.1"
+              ocaml-compiler: "5.3"
               dune-cache: true
 
          - name: Deps

--- a/README.md
+++ b/README.md
@@ -159,14 +159,28 @@ let http_request ?headers ?body action url =
 Contributing
 ------------
 
-1. Create an opam switch and install the dependencies (opam >= 2.2 is recommended for the `--with-dev-setup` flag):
+This package actively supports and develops for both OCaml 4 and OCaml 5. However, a core dependency for one usage-pattern, `eio`, is only available on OCaml 5. To fully build and test this package, you'll need an OCaml 5 environment; but testing on OCaml 4 is also required in general.
+
+For simple changes, just using an OCaml 5 switch is sufficient; however, you may not see breakage with OCaml 4 until your changes hit CI. For more complex changes, or a faster turnaround, you may want to maintain separate `ambient-context` switches for both versions of OCaml:
+
+1. Create opam switches and install the dependencies (opam >= 2.2 is recommended for the `--with-dev-setup` flag.)
+
+   To create separate switches (and to generate/modify lockfiles), there's a helper script - simply run that. (This will default to linking the OCaml 4 into the working-directory.)
 
    ```console
-   $ opam switch create . ocaml.4.14.2 --deps-only --no-install
-   $ eval $(opam env --switch=.)
+   $ ./scripts/regenerate_switches.sh --locked
+   $ eval "$(opam env --set-switch --switch=.)"
+   ```
 
-   $ opam install ./ambient-context.opam \
-      --deps-only --with-test --with-dev-setup
+   Alternatively, if you aren't regenerating lockfiles, you can get away with a single OCaml 5 directory-local switch instead:
+
+   ```console
+   $ opam switch create . --deps-only --locked --no-install \
+      --formula='"ocaml-base-compiler" {>= "5.0" & < "6.0"}'
+   $ eval "$(opam env --set-switch --switch=.)"
+
+   $ opam install . --deps-only --locked \
+      --with-doc --with-test --with-dev-setup
    ```
 
 2. [Install pre-commit][], and then configure your checkout:

--- a/ambient-context-eio.opam.locked
+++ b/ambient-context-eio.opam.locked
@@ -1,0 +1,118 @@
+opam-version: "2.0"
+name: "ambient-context-eio"
+version: "0.1.1"
+synopsis:
+  "Storage backend for ambient-context using Eio's continuation-local storage"
+maintainer: "ELLIOTTCABLE <opam@ell.io>"
+authors: "ELLIOTTCABLE"
+license: "MIT"
+homepage: "https://github.com/ELLIOTTCABLE/ocaml-ambient-context"
+bug-reports: "https://github.com/ELLIOTTCABLE/ocaml-ambient-context/issues"
+depends: [
+  "alcotest" {= "1.9.1" & with-test}
+  "alcotest-lwt" {= "1.9.1" & with-test}
+  "ambient-context" {= "0.1.1"}
+  "astring" {= "0.8.5" & with-test}
+  "b0" {= "0.0.5" & with-doc}
+  "base" {= "v0.17.3" & with-dev-setup}
+  "base-bigarray" {= "base"}
+  "base-bytes" {= "base" & with-test}
+  "base-domains" {= "base"}
+  "base-nnp" {= "base"}
+  "base-threads" {= "base"}
+  "base-unix" {= "base"}
+  "bigstringaf" {= "0.10.0"}
+  "bisect_ppx" {= "2.8.3" & with-test}
+  "camlp-streams" {= "5.0.1" & with-doc}
+  "chrome-trace" {= "3.21.0" & with-dev-setup}
+  "cmdliner" {= "1.3.0"}
+  "cppo" {= "1.8.0" & with-test}
+  "crunch" {= "4.0.0" & with-doc}
+  "csexp" {= "1.5.2"}
+  "cstruct" {= "6.2.0"}
+  "domain-local-await" {= "1.0.1"}
+  "dune" {= "3.21.0"}
+  "dune-build-info" {= "3.21.0" & with-dev-setup}
+  "dune-configurator" {= "3.21.0"}
+  "dune-rpc" {= "3.21.0" & with-dev-setup}
+  "dyn" {= "3.21.0" & with-dev-setup}
+  "eio" {= "1.3"}
+  "either" {= "1.0.0" & with-dev-setup}
+  "fiber" {= "3.7.0" & with-dev-setup}
+  "fix" {= "20250919" & with-dev-setup}
+  "fmt" {= "0.11.0"}
+  "fpath" {= "0.7.3" & with-doc}
+  "fs-io" {= "3.21.0" & with-dev-setup}
+  "hmap" {= "0.8.1"}
+  "jsonrpc" {= "1.21.0" & with-dev-setup}
+  "logs" {= "0.10.0" & with-test}
+  "lsp" {= "1.21.0" & with-dev-setup}
+  "lwt" {= "6.1.0" & with-test}
+  "lwt-dllist" {= "1.1.0"}
+  "menhir" {= "20260122" & with-dev-setup}
+  "menhirCST" {= "20260122" & with-dev-setup}
+  "menhirGLR" {= "20260122" & with-dev-setup}
+  "menhirLib" {= "20260122" & with-dev-setup}
+  "menhirSdk" {= "20260122" & with-dev-setup}
+  "merlin-lib" {= "5.3-502" & with-dev-setup}
+  "mtime" {= "2.1.0"}
+  "ocaml" {= "5.2.1"}
+  "ocaml-base-compiler" {= "5.2.1"}
+  "ocaml-compiler-libs" {= "v0.17.0" & with-test}
+  "ocaml-config" {= "3"}
+  "ocaml-lsp-server" {= "1.21.0" & with-dev-setup}
+  "ocaml-options-vanilla" {= "1"}
+  "ocaml-syntax-shims" {= "1.0.0" & with-test}
+  "ocaml-version" {= "4.0.3" & with-dev-setup}
+  "ocaml_intrinsics_kernel" {= "v0.17.1" & with-dev-setup}
+  "ocamlbuild" {= "0.16.1"}
+  "ocamlc-loc" {= "3.21.0" & with-dev-setup}
+  "ocamlfind" {= "1.9.8"}
+  "ocamlformat" {= "0.28.1" & with-dev-setup}
+  "ocamlformat-lib" {= "0.28.1" & with-dev-setup}
+  "ocamlformat-rpc-lib" {= "0.28.1" & with-dev-setup}
+  "ocp-indent" {= "1.9.0" & with-dev-setup}
+  "ocplib-endian" {= "1.2" & with-test}
+  "odig" {= "0.0.9" & with-doc}
+  "odoc" {= "3.1.0" & with-doc}
+  "odoc-parser" {= "3.1.0" & with-doc}
+  "optint" {= "0.3.0"}
+  "ordering" {= "3.21.0" & with-dev-setup}
+  "pp" {= "2.0.0" & with-dev-setup}
+  "ppx_derivers" {= "1.2.1" & with-test}
+  "ppx_yojson_conv_lib" {= "v0.17.0" & with-dev-setup}
+  "ppxlib" {= "0.35.0" & with-test}
+  "psq" {= "0.2.1"}
+  "ptime" {= "1.2.0" & with-doc}
+  "re" {= "1.14.0" & with-test}
+  "seq" {= "base"}
+  "sexplib0" {= "v0.17.0" & with-test}
+  "spawn" {= "v0.17.0" & with-dev-setup}
+  "stdio" {= "v0.17.0" & with-dev-setup}
+  "stdlib-shims" {= "0.3.0" & with-test}
+  "stdune" {= "3.21.0" & with-dev-setup}
+  "thread-table" {= "1.0.0"}
+  "top-closure" {= "3.21.0" & with-dev-setup}
+  "topkg" {= "1.1.1"}
+  "tyxml" {= "4.6.0" & with-doc}
+  "uucp" {= "17.0.0" & with-dev-setup}
+  "uuseg" {= "17.0.0" & with-dev-setup}
+  "uutf" {= "1.0.4" & with-test}
+  "xdg" {= "3.21.0" & with-dev-setup}
+  "yojson" {= "2.2.2" & with-dev-setup}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ELLIOTTCABLE/ocaml-ambient-context.git"

--- a/ambient-context-lwt.opam.locked
+++ b/ambient-context-lwt.opam.locked
@@ -1,0 +1,103 @@
+opam-version: "2.0"
+name: "ambient-context-lwt"
+version: "0.1.1"
+synopsis:
+  "Storage backend for ambient-context using Lwt's sequence-associated storage"
+maintainer: "ELLIOTTCABLE <opam@ell.io>"
+authors: "ELLIOTTCABLE"
+license: "MIT"
+homepage: "https://github.com/ELLIOTTCABLE/ocaml-ambient-context"
+bug-reports: "https://github.com/ELLIOTTCABLE/ocaml-ambient-context/issues"
+depends: [
+  "alcotest" {= "1.9.1" & with-test}
+  "alcotest-lwt" {= "1.9.1" & with-test}
+  "ambient-context" {= "0.1.1"}
+  "astring" {= "0.8.5" & with-test}
+  "b0" {= "0.0.5" & with-doc}
+  "base" {= "v0.16.4" & with-dev-setup}
+  "base-bigarray" {= "base"}
+  "base-bytes" {= "base"}
+  "base-threads" {= "base"}
+  "base-unix" {= "base"}
+  "bisect_ppx" {= "2.8.3" & with-test}
+  "camlp-streams" {= "5.0.1" & with-doc}
+  "chrome-trace" {= "3.21.0" & with-dev-setup}
+  "cmdliner" {= "1.3.0" & with-test}
+  "cppo" {= "1.8.0"}
+  "crunch" {= "4.0.0" & with-doc}
+  "csexp" {= "1.5.2"}
+  "dune" {= "3.21.0"}
+  "dune-build-info" {= "3.21.0" & with-dev-setup}
+  "dune-configurator" {= "3.21.0"}
+  "dune-rpc" {= "3.21.0" & with-dev-setup}
+  "dyn" {= "3.21.0" & with-dev-setup}
+  "either" {= "1.0.0" & with-dev-setup}
+  "fiber" {= "3.7.0" & with-dev-setup}
+  "fix" {= "20250919" & with-dev-setup}
+  "fmt" {= "0.11.0" & with-test}
+  "fpath" {= "0.7.3" & with-doc}
+  "fs-io" {= "3.21.0" & with-dev-setup}
+  "logs" {= "0.10.0" & with-test}
+  "lwt" {= "6.1.0"}
+  "menhir" {= "20260122" & with-dev-setup}
+  "menhirCST" {= "20260122" & with-dev-setup}
+  "menhirGLR" {= "20260122" & with-dev-setup}
+  "menhirLib" {= "20260122" & with-dev-setup}
+  "menhirSdk" {= "20260122" & with-dev-setup}
+  "merlin-lib" {= "4.16-414" & with-dev-setup}
+  "ocaml" {= "4.14.2"}
+  "ocaml-base-compiler" {= "4.14.2"}
+  "ocaml-compiler-libs" {= "v0.12.4" & with-test}
+  "ocaml-config" {= "2"}
+  "ocaml-lsp-server" {= "1.17.0" & with-dev-setup}
+  "ocaml-options-vanilla" {= "1"}
+  "ocaml-syntax-shims" {= "1.0.0" & with-test}
+  "ocaml-version" {= "4.0.3" & with-dev-setup}
+  "ocamlbuild" {= "0.16.1" & with-test}
+  "ocamlc-loc" {= "3.21.0" & with-dev-setup}
+  "ocamlfind" {= "1.9.8"}
+  "ocamlformat" {= "0.28.1" & with-dev-setup}
+  "ocamlformat-lib" {= "0.28.1" & with-dev-setup}
+  "ocamlformat-rpc-lib" {= "0.28.1" & with-dev-setup}
+  "ocp-indent" {= "1.9.0" & with-dev-setup}
+  "ocplib-endian" {= "1.2"}
+  "odig" {= "0.0.9" & with-doc}
+  "odoc" {= "3.1.0" & with-doc}
+  "odoc-parser" {= "3.1.0" & with-doc}
+  "ordering" {= "3.21.0" & with-dev-setup}
+  "pp" {= "2.0.0" & with-dev-setup}
+  "ppx_derivers" {= "1.2.1" & with-test}
+  "ppx_yojson_conv_lib" {= "v0.16.0" & with-dev-setup}
+  "ppxlib" {= "0.35.0" & with-test}
+  "ptime" {= "1.2.0" & with-doc}
+  "re" {= "1.14.0" & with-test}
+  "seq" {= "base" & with-doc}
+  "sexplib0" {= "v0.16.0" & with-test}
+  "spawn" {= "v0.17.0" & with-dev-setup}
+  "stdio" {= "v0.16.0" & with-dev-setup}
+  "stdlib-shims" {= "0.3.0" & with-test}
+  "stdune" {= "3.21.0" & with-dev-setup}
+  "top-closure" {= "3.21.0" & with-dev-setup}
+  "topkg" {= "1.1.1" & with-test}
+  "tyxml" {= "4.6.0" & with-doc}
+  "uucp" {= "17.0.0" & with-dev-setup}
+  "uuseg" {= "17.0.0" & with-dev-setup}
+  "uutf" {= "1.0.4" & with-test}
+  "xdg" {= "3.21.0" & with-dev-setup}
+  "yojson" {= "2.2.2" & with-dev-setup}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ELLIOTTCABLE/ocaml-ambient-context.git"

--- a/ambient-context.opam.locked
+++ b/ambient-context.opam.locked
@@ -1,0 +1,98 @@
+opam-version: "2.0"
+name: "ambient-context"
+version: "0.1.1"
+synopsis:
+  "Abstraction over thread-local / continuation-local storage mechanisms for communication with transitive dependencies"
+maintainer: "ELLIOTTCABLE <opam@ell.io>"
+authors: "ELLIOTTCABLE"
+license: "MIT"
+homepage: "https://github.com/ELLIOTTCABLE/ocaml-ambient-context"
+bug-reports: "https://github.com/ELLIOTTCABLE/ocaml-ambient-context/issues"
+depends: [
+  "alcotest" {= "1.9.1" & with-test}
+  "astring" {= "0.8.5" & with-test}
+  "b0" {= "0.0.5" & with-doc}
+  "base" {= "v0.16.4" & with-dev-setup}
+  "base-bigarray" {= "base"}
+  "base-threads" {= "base"}
+  "base-unix" {= "base"}
+  "bisect_ppx" {= "2.8.3" & with-test}
+  "camlp-streams" {= "5.0.1" & with-doc}
+  "chrome-trace" {= "3.21.0" & with-dev-setup}
+  "cmdliner" {= "1.3.0" & with-test}
+  "cppo" {= "1.8.0" & with-doc}
+  "crunch" {= "4.0.0" & with-doc}
+  "csexp" {= "1.5.2" & with-dev-setup}
+  "dune" {= "3.21.0"}
+  "dune-build-info" {= "3.21.0" & with-dev-setup}
+  "dune-configurator" {= "3.21.0" & with-dev-setup}
+  "dune-rpc" {= "3.21.0" & with-dev-setup}
+  "dyn" {= "3.21.0" & with-dev-setup}
+  "either" {= "1.0.0" & with-dev-setup}
+  "fiber" {= "3.7.0" & with-dev-setup}
+  "fix" {= "20250919" & with-dev-setup}
+  "fmt" {= "0.11.0" & with-test}
+  "fpath" {= "0.7.3" & with-doc}
+  "fs-io" {= "3.21.0" & with-dev-setup}
+  "menhir" {= "20260122" & with-dev-setup}
+  "menhirCST" {= "20260122" & with-dev-setup}
+  "menhirGLR" {= "20260122" & with-dev-setup}
+  "menhirLib" {= "20260122" & with-dev-setup}
+  "menhirSdk" {= "20260122" & with-dev-setup}
+  "merlin-lib" {= "4.16-414" & with-dev-setup}
+  "ocaml" {= "4.14.2"}
+  "ocaml-base-compiler" {= "4.14.2"}
+  "ocaml-compiler-libs" {= "v0.12.4" & with-test}
+  "ocaml-config" {= "2"}
+  "ocaml-lsp-server" {= "1.17.0" & with-dev-setup}
+  "ocaml-options-vanilla" {= "1"}
+  "ocaml-syntax-shims" {= "1.0.0" & with-test}
+  "ocaml-version" {= "4.0.3" & with-dev-setup}
+  "ocamlbuild" {= "0.16.1" & with-test}
+  "ocamlc-loc" {= "3.21.0" & with-dev-setup}
+  "ocamlfind" {= "1.9.8" & with-test}
+  "ocamlformat" {= "0.28.1" & with-dev-setup}
+  "ocamlformat-lib" {= "0.28.1" & with-dev-setup}
+  "ocamlformat-rpc-lib" {= "0.28.1" & with-dev-setup}
+  "ocp-indent" {= "1.9.0" & with-dev-setup}
+  "odig" {= "0.0.9" & with-doc}
+  "odoc" {= "3.1.0" & with-doc}
+  "odoc-parser" {= "3.1.0" & with-doc}
+  "ordering" {= "3.21.0" & with-dev-setup}
+  "pp" {= "2.0.0" & with-dev-setup}
+  "ppx_derivers" {= "1.2.1" & with-test}
+  "ppx_yojson_conv_lib" {= "v0.16.0" & with-dev-setup}
+  "ppxlib" {= "0.35.0" & with-test}
+  "ptime" {= "1.2.0" & with-doc}
+  "re" {= "1.14.0" & with-test}
+  "seq" {= "base" & with-doc}
+  "sexplib0" {= "v0.16.0" & with-test}
+  "spawn" {= "v0.17.0" & with-dev-setup}
+  "stdio" {= "v0.16.0" & with-dev-setup}
+  "stdlib-shims" {= "0.3.0" & with-test}
+  "stdune" {= "3.21.0" & with-dev-setup}
+  "top-closure" {= "3.21.0" & with-dev-setup}
+  "topkg" {= "1.1.1" & with-test}
+  "tyxml" {= "4.6.0" & with-doc}
+  "uucp" {= "17.0.0" & with-dev-setup}
+  "uuseg" {= "17.0.0" & with-dev-setup}
+  "uutf" {= "1.0.4" & with-test}
+  "xdg" {= "3.21.0" & with-dev-setup}
+  "yojson" {= "2.2.2" & with-dev-setup}
+]
+conflicts: ["hmap"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ELLIOTTCABLE/ocaml-ambient-context.git"

--- a/scripts/regenerate_switches.sh
+++ b/scripts/regenerate_switches.sh
@@ -1,0 +1,95 @@
+#!/bin/sh
+# shellcheck shell=dash
+set -eu
+
+#  This script sets up opam switches and generates lockfiles.
+#
+#  Usage:
+#     ./scripts/regenerate_switches.sh [--locked|--regen-locks]
+#
+#     --locked
+#        Create switches and install dependencies using existing lockfiles. Does not modify
+#        lockfiles.
+#     --regen-locks
+#        Create switches, install dependencies, and immediately regenerate lockfiles with the
+#        results of those clean installations.
+
+SWITCH_PREFIX="ambient-context"
+OCAML_4_FORMULA='"ocaml-base-compiler" {>= "4.08" & < "5.0"}'
+OCAML_5_FORMULA='"ocaml-base-compiler" {>= "5.0" & < "6.0"}'
+export OPAMYES=1
+
+script_name="$(basename "$0")"
+puts() { printf %s\\n "$@" ;}
+logs() { printf '\033[90m[%s %s]\033[0m %s\n' "$(date +%T)" "$script_name" "$*" ;}
+loge() { printf '\033[91m[%s %s]\033[0m !! %s\n' "$(date +%T)" "$script_name" "$*" >&2 ;}
+argq() { [ $# -gt 0 ] && printf "'%s' " "$@" ;}
+
+if [ "$1" = "--regen-locks" ]; then
+   regen_locks=true
+   shift
+
+   if [ "$#" -ne 0 ]; then
+      loge "Usage: $0 [--locked|--regen-locks]"
+      exit 100
+   fi
+
+elif [ "$1" = "--locked" ]; then
+   regen_locks=false
+
+   if [ "$#" -ne 1 ]; then
+      loge "Usage: $0 [--locked|--regen-locks]"
+      exit 100
+   fi
+
+elif [ "$#" -ne 0 ]; then
+   loge "Usage: $0 [--locked|--regen-locks]"
+   exit 100
+fi
+
+cd "$(dirname "$0")/.." || exit 101
+
+# --- --- ---
+
+setup_switch() {
+   switch_name="$1" && shift
+   formula="$1" && shift
+   package_file="$1" && shift
+
+   full_switch="${SWITCH_PREFIX}-${switch_name}"
+
+   if opam switch list --short | grep -qx "$full_switch"; then
+      logs "Resetting existing '$full_switch'..."
+      # shellcheck disable=SC2046
+      opam remove --switch="$full_switch" --auto-remove $(
+         opam list --switch="$full_switch" --roots --short \
+         | grep -v 'ocaml-base-compiler\|ocaml-options\|ocaml-config\|base-'
+      )
+   else
+      logs "Creating '$full_switch' with invariant '$formula'..."
+      opam switch create "$full_switch" --formula="$formula" \
+         "$@" --deps-only --no-install
+   fi
+
+   logs "Installing dependencies for '$package_file'..."
+   opam install --switch="$full_switch" "./$package_file" \
+      "$@" --deps-only --with-doc --with-test --with-dev-setup
+
+   if [ "$regen_locks" = true ]; then
+      logs "Regenerating lockfile for '$package_file'..."
+      opam lock --switch="$full_switch" "./$package_file"
+   fi
+}
+
+setup_switch "ocaml-4"     "$OCAML_4_FORMULA" "ambient-context.opam"     "$@"
+setup_switch "lwt-ocaml-4" "$OCAML_4_FORMULA" "ambient-context-lwt.opam" "$@"
+setup_switch "eio-ocaml-5" "$OCAML_5_FORMULA" "ambient-context-eio.opam" "$@"
+
+if ! [ -d "_opam" ]; then
+   opam switch link "${SWITCH_PREFIX}-ocaml-4" .
+fi
+
+logs "All done; now run this to sync your shell environment:"
+logs ''
+# shellcheck disable=SC2016
+logs '    eval $(opam env --set-switch --switch='"$SWITCH_PREFIX"'-ocaml-4)'


### PR DESCRIPTION
This adds lockfiles for the current state of the dependencies in `main`.

It also updates the README instructions to use them; as well as adding a script to generate them that uses clean states / switches (to bypass opam's odd behaviour re: locking deps from the live state.)

Finally, it starts to setup CI to build from lockfiles by default (on push/PR), with cron-testing of unlocked build against the latest resolvable dependencies.